### PR TITLE
be more specific about minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 
 GLM 0.6
 DataFrames


### PR DESCRIPTION
since `abstract type` wouldn't work for versions before february


sorry for so many little tweaks - if you agree with this one, I can modify the metadata PR in place, no need to re-tag