### PR TITLE
Fix issue #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ If one wants to estimate the long-time variance using the same kernel, but with 
 ```julia
 vcov(lm1, QuadraticSpectralKernel(NeweyWest), prewhite = false)
 ```
-The standard errors can be obtained by the `stderr` method
+The standard errors can be obtained by the `stderror` method
 ```julia
-stderr(::DataFrameRegressionModel, ::HAC; prewhite::Bool)
+stderror(::DataFrameRegressionModel, ::HAC; prewhite::Bool)
 ```
 Sometime is useful to access the bandwidth selected by the automatic procedures. This can be done using the `optimalbw` method
 ```julia
@@ -98,7 +98,7 @@ optimalbw(Andrews, QuadraticSpectralKernel, lm1; prewhite = false)
 
 ### Long run variance of the average of the process
 
-Sometime interest lies in estimating the long-run variance of the average of the process. At the moment this can be done by carrying out a regression on a constant (the sample mean of the realization of the process) and using `vcov` or `stderr` to obtain a consistent variance.
+Sometime interest lies in estimating the long-run variance of the average of the process. At the moment this can be done by carrying out a regression on a constant (the sample mean of the realization of the process) and using `vcov` or `stderror` to obtain a consistent variance estimate (or its diagonal elements).
 
 ```julia
 lm2 = glm(u~1, df, Normal(), IdentityLink())

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-StatsBase 
+StatsBase 0.22.0
 StatsModels 0.2.1
 GLM 0.6
 DataFrames 0.11

--- a/src/CovarianceMatrices.jl
+++ b/src/CovarianceMatrices.jl
@@ -11,7 +11,7 @@ abstract type CRHC <: RobustVariance end
 @reexport using GLM
 @reexport using DataFrames
 
-import StatsBase: confint, stderr, vcov, nobs, residuals, RegressionModel
+import StatsBase: confint, stderror, vcov, nobs, residuals, RegressionModel
 import GLM: LinPredModel, LinearModel, GeneralizedLinearModel, ModelMatrix, df_residual, AbstractGLM
 import StatsModels: DataFrameRegressionModel
 
@@ -19,7 +19,7 @@ const twohalftoπ² = 2.5 / π^2
 
 export QuadraticSpectralKernel, TruncatedKernel, ParzenKernel, BartlettKernel,
        TukeyHanningKernel, VARHAC, HC0, HC1, HC2, HC3, HC4, HC4m, HC5, CRHC0, CRHC1,
-       CRHC2, CRHC3, vcov, NeweyWest, Andrews, optimalbw
+       CRHC2, CRHC3, vcov, stderror, NeweyWest, Andrews, optimalbw
 
 mutable struct HC0  <: HC end
 mutable struct HC1  <: HC end

--- a/src/HAC.jl
+++ b/src/HAC.jl
@@ -161,7 +161,7 @@ function vcov(X::AbstractMatrix, k::QuadraticSpectralKernel, bw, D, prewhite::Bo
 end
 
 vcov(r::DataFrameRegressionModel, k::HAC{T}; args...) where {T<:Fixed} = variance(r, k; args...)
-stderr(x::DataFrameRegressionModel, k::HAC; kwargs...) = sqrt.(diag(vcov(x, k; kwargs...)))
+stderror(x::DataFrameRegressionModel, k::HAC; kwargs...) = sqrt.(diag(vcov(x, k; kwargs...)))
 
 function vcov(r::DataFrameRegressionModel, k::HAC{Optimal{T}}; args...) where T<:OptimalBandwidth
     p = size(r.model.pp.X, 2)

--- a/src/HC.jl
+++ b/src/HC.jl
@@ -243,17 +243,17 @@ vcov(r::T, k::Type{R}) where {T<:DataFrameRegressionModel, R<:HC} = sandwhich(r,
 vcov(r::T, k::Type{R}) where {T<:AbstractGLM, R<:HC} = sandwhich(r, k())
 vcov(r::T, k::Type{R}) where {T<:LinearModel, R<:HC} = sandwhich(r, k())
 
-stderr(r::T, k::CRHC) where {T<:DataFrameRegressionModel} = sqrt.(diag(sandwhich(r, k)))
-stderr(r::T, k::CRHC) where {T<:AbstractGLM} = sqrt.(diag(sandwhich(r, k)))
-stderr(r::T, k::CRHC) where {T<:LinearModel} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::CRHC) where {T<:DataFrameRegressionModel} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::CRHC) where {T<:AbstractGLM} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::CRHC) where {T<:LinearModel} = sqrt.(diag(sandwhich(r, k)))
 
-stderr(r::T, k::HC) where {T<:DataFrameRegressionModel} = sqrt.(diag(sandwhich(r, k)))
-stderr(r::T, k::HC) where {T<:AbstractGLM} = sqrt.(diag(sandwhich(r, k)))
-stderr(r::T, k::HC) where {T<:LinearModel} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::HC) where {T<:DataFrameRegressionModel} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::HC) where {T<:AbstractGLM} = sqrt.(diag(sandwhich(r, k)))
+stderror(r::T, k::HC) where {T<:LinearModel} = sqrt.(diag(sandwhich(r, k)))
 
-stderr(r::T, k::Type{R}) where {T<:DataFrameRegressionModel, R<:HC} = sqrt.(diag(sandwhich(r, k())))
-stderr(r::T, k::Type{R}) where {T<:AbstractGLM, R<:HC} = sqrt.(diag(sandwhich(r, k())))
-stderr(r::T, k::Type{R}) where {T<:LinearModel, R<:HC} = sqrt.(diag(sandwhich(r, k())))
+stderror(r::T, k::Type{R}) where {T<:DataFrameRegressionModel, R<:HC} = sqrt.(diag(sandwhich(r, k())))
+stderror(r::T, k::Type{R}) where {T<:AbstractGLM, R<:HC} = sqrt.(diag(sandwhich(r, k())))
+stderror(r::T, k::Type{R}) where {T<:LinearModel, R<:HC} = sqrt.(diag(sandwhich(r, k())))
 
 
 

--- a/src/varhac.jl
+++ b/src/varhac.jl
@@ -20,10 +20,17 @@ function varhac(dat,imax,ilag,imodel)
     ## ccc:        VARHAC estimator
 
 
-    global ex, ex1, ex2, dat2, dep
+    #global ex, ex1, ex2, dat2, dep
+
 
     nt   = size(dat, 1)
     kdim = size(dat, 2)
+
+    ex   = dat[imax:nt-1, :];
+    dat2 = dat[imax:nt-1, :];
+    ex1  = dat[imax:nt-1, :]
+    ex2  = dat[imax:nt-1, :]
+    dep  = dat[imax+1:nt, 1]
 
     ddd      = dat[imax+1:nt, :]
     minres   = ddd

--- a/test/ols_hac.jl
+++ b/test/ols_hac.jl
@@ -137,7 +137,7 @@ Vt = [0.00417663470962045 -0.00014277423204925 0.000404820124045818
      -0.00014277423204925 0.00310914818879932 -0.000418125055191947
       0.000404820124045818 -0.000418125055191946 0.00345356514902845]
 @test V≈Vt atol=1e-4
-@test stderr(lm1,ParzenKernel(Andrews), prewhite = true) ≈ sqrt.(diag(Vt)) atol = 0.001
+@test stderror(lm1,ParzenKernel(Andrews), prewhite = true) ≈ sqrt.(diag(Vt)) atol = 0.001
 
 V = vcov(lm1, QuadraticSpectralKernel(Andrews), prewhite = true)
 Vt = [0.00422525037811967 -0.000131637826271777 0.000413149700377485
@@ -145,7 +145,7 @@ Vt = [0.00422525037811967 -0.000131637826271777 0.000413149700377485
       0.000413149700377485 -0.000420524137687161 0.00342999158493283]
 
 @test V≈Vt atol=1e-4
-@test stderr(lm1, QuadraticSpectralKernel(Andrews), prewhite = true) ≈ sqrt.(diag(Vt)) atol = 0.001
+@test stderror(lm1, QuadraticSpectralKernel(Andrews), prewhite = true) ≈ sqrt.(diag(Vt)) atol = 0.001
 
 
 @test optimalbw(Andrews, BartlettKernel, lm1) ≈ 1.79655260917

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,10 +270,10 @@ S4 = vcov(OLS, HC4())
 S5 = vcov(OLS, HC5())
 
 cl = convert(Array, df[:cl])
-S0 = stderr(OLS, CRHC0(cl))
-S1 = stderr(OLS, CRHC1(cl))
-S2 = stderr(OLS, CRHC2(cl))
-S3 = stderr(OLS, CRHC3(cl))
+S0 = stderror(OLS, CRHC0(cl))
+S1 = stderror(OLS, CRHC1(cl))
+S2 = stderror(OLS, CRHC2(cl))
+S3 = stderror(OLS, CRHC3(cl))
 
 
 ## STATA
@@ -286,12 +286,12 @@ St1 = [.0374668, .0497666, .0472636, .0437952, .0513613, .0435369]
 
 
 wOLS = fit(GeneralizedLinearModel, @formula(Y~X1+X2+X3+X4+X5), df,
-          Normal(), IdentityLink(), wts = convert(Array, df[:w]))
+          Normal(), IdentityLink(), wts = convert(Array{Float64}, df[:w]))
 
-S0 = stderr(wOLS, CRHC0(cl))
-S1 = stderr(wOLS, CRHC1(cl))
-S2 = stderr(wOLS, CRHC2(cl))
-S3 = stderr(wOLS, CRHC3(cl))
+S0 = stderror(wOLS, CRHC0(cl))
+S1 = stderror(wOLS, CRHC1(cl))
+S2 = stderror(wOLS, CRHC2(cl))
+S3 = stderror(wOLS, CRHC3(cl))
 
 St1 = [0.042839848169137905,0.04927285387211425,
        0.05229519531359171,0.041417170723876025,
@@ -307,7 +307,7 @@ St1 = [0.042839848169137905,0.04927285387211425,
 # x = randn(100, 5);
 
 # lm1 = lm(x, y)
-# @test stderr(lm1, HC0())≈[0.0941998, 0.0946132, 0.0961678, 0.0960445, 0.101651] atol=1e-06
+# @test stderror(lm1, HC0())≈[0.0941998, 0.0946132, 0.0961678, 0.0960445, 0.101651] atol=1e-06
 # @test diag(vcov(lm1, HC0()))≈[0.0941998, 0.0946132, 0.0961678, 0.0960445, 0.101651].^2 atol=1e-06
 
 ############################################################


### PR DESCRIPTION
This should fix issue #31  from @andreasnoack.

- Make sure columns from DataFrame are of type `Array{Float64, N}` when passed down to `GLM` (this was happening in some of the tests)
- Use `stderror` instead of `stderr` (due to naming change in `StatsBase.jl` 0.22)
- Reauire: Add lower bound on StatsBase (0.22.0)