### PR TITLE
Cap StatsModels at 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
+[compat]
+StatsModels = "0.1, 0.2, 0.3, 0.4, 0.5"
+
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
StatsModels v0.6 is a breaking change: [https://discourse.julialang.org/t/psa-breaking-changes-in-statsmodels-v0-6-0-terms-2-0-son-of-terms/]